### PR TITLE
Add Logjam code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ workflows:
       - test_code:
           matrix:
             parameters:
-              clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
+              clojure_version: ["1.9", "1.10", "1.11"]
               jdk_version: [openjdk8, openjdk11, openjdk17]
           filters:
             branches:

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,10 +1,12 @@
-{:linters {:discouraged-var                       {clojure.core/read-string {:message "Please prefer clojure.edn/read-string"}}
+{:lint-as {logjam.repl-test/with-each-framework    clojure.core/let
+           clojure.test.check.clojure-test/defspec clojure.test/deftest
+           clojure.test.check.properties/for-all   clojure.core/let}
+ :linters {:discouraged-var                       {clojure.core/read-string {:message "Please prefer clojure.edn/read-string"}}
            ;; Enable some disabled-by-default linters.
            :docstring-leading-trailing-whitespace {:level :warning}
            :keyword-binding                       {:level :warning}
            :reduce-without-init                   {:level :warning}
            :redundant-fn-wrapper                  {:level :warning}
-           :shadowed-var                          {:level :warning}
            :single-key-in                         {:level :warning}
            :unsorted-required-namespaces          {:level :warning}
            :used-underscored-binding              {:level :warning}}}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ install.cmd
 /.lein-env
 .inline-deps
 .clj-kondo/.cache/
+/.eastwood

--- a/README.md
+++ b/README.md
@@ -7,6 +7,102 @@
 
 # Logjam
 
+Logjam is a library to capture log events emitted by Java logging
+frameworks. Log events are captured as a Clojure data structure in an
+in-memory atom, which can be searched, inspected and listened to.
+
+Logjam is designed to be used by tooling such as [CIDER](https://cider.mx/)'s [Log
+Mode](https://docs.cider.mx/cider/debugging/logging.html), but can also be used with a plain REPL in combination with
+[REBL](https://docs.datomic.com/cloud/other-tools/REBL.html) or [Morse](https://github.com/nubank/morse).
+
+## Overview
+
+### Log Framework
+
+Logjam supports log frameworks that allow reconfiguration at run
+time. More specifically the framework should support attaching log
+appenders to loggers, in order to capture events.
+
+At the moment the following log frameworks are supported:
+
+- [Java Util Logging](https://docs.oracle.com/en/java/javase/19/core/java-logging-overview.html)
+- [Logback](https://logback.qos.ch)
+
+### Log Appender
+
+In order to capture log events, a log appender needs to be attached to
+a logger of a framework. Once an appender is attached to a logger it
+captures the log events emitted by the framework in an in-memory
+atom. A log appender can be configured to have a certain size
+(default: 100000) and a threshold in percentage (default: 10). Log
+events are cleared from the appender when threshold (appender size
+plus threshold in percentage of the appender size) is
+reached. Additionally an appender can be configured to only capture
+events that match a set of filters.
+
+### Log Consumer
+
+Log events can be streamed to a client by attaching a log consumer to
+an appender. Once a log consumer has been attached to an appender, it
+will receive events from the appender. Similar to log appenders,
+consumers can also be configured with a set of filters to only receive
+certain events.
+
+### Log Events
+
+Log events can be searched, streamed to a client or viewed in CIDER's
+Inspector and Stacktrace Mode. When searching log events the user can
+specify a set of filters. Events that match the filters are shown in
+the `+*cider-log*+` buffer. Additionally a log consumer will be
+attached to the appender to receive log events matching the search
+criteria after the search command has been issued. The log appender
+will be removed automatically once a new search has been submitted or
+when the `+*cider-log*+` buffer gets killed.
+
+### Log Filters
+
+Filters for log events can be attached to log appenders and
+consumers. They also take effect when searching events or streaming
+them to clients. If multiple filters are chosen they are combined
+using logical AND condition. The following filters are available:
+
+## Usage
+
+Logjam is used by [CIDER](https://cider.mx/)'s [LogMode](https://docs.cider.mx/cider/debugging/logging.html), but can also be used in a
+standalone REPL. Here is an example how such a REPL session could look
+like:
+
+``` clojure
+;; Use the :logback logging framework
+(repl/set-framework! :logback)
+
+;; Add an appender to the log framework that captures events.
+(repl/add-appender)
+
+;; Log something
+(repl/log :message \"hello\")
+
+;; Return all captured log events
+(repl/events)
+
+;; Search log events with :message field matching a regex :pattern
+(repl/events :pattern \"hel.*\")
+
+;; Search log events by level
+(repl/events :level :INFO)
+
+;; Add a log consumer that prints log events
+(repl/add-consumer
+  :callback (fn [_consumer event]
+              (clojure.pprint/pprint event)))
+
+;; Log something else
+(repl/log :message \"world\")
+
+;; Remove all consumers and appenders
+(repl/shutdown)
+```
+
 ## Development
 
 #### Deployment
@@ -20,8 +116,14 @@ git push --tags
 
 ## [Changelog](CHANGELOG.md)
 
+## Thanks
+
+Thanks to @rafaeldff for his initial idea on capturing the logs and
+supporting this project. Some of the code in this repository is based
+on his private development tooling.
+
 ## License
 
-Copyright © 2023
+Copyright © 2023 CIDER Contributors
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/eastwood.clj
+++ b/eastwood.clj
@@ -1,0 +1,4 @@
+(disable-warning
+ {:linter :deprecations
+  :symbol-matches #{#"^public int java\.util\.logging\.LogRecord\.getThreadID\(\)$"}
+  :reason "The replacement, getLongThreadID, was added in JDK16 – but we still support JDK8."})

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
-  :profiles {:provided {:dependencies [[org.clojure/clojure "1.11.1"]]}
-
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+  :profiles {:provided {:dependencies [;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
+                                       [ch.qos.logback/logback-classic "1.3.7"]
+                                       [org.clojure/clojure "1.11.1"]]}
 
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
 
@@ -30,10 +30,15 @@
                       :dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]
                                      [org.clojure/clojure "1.12.0-master-SNAPSHOT" :classifier "sources"]]}
 
+             :test {:jvm-opts ["-Djava.util.logging.config.file=test/resources/logging.properties"]
+                    :resource-paths ["test/resources"]
+                    :dependencies [[org.clojure/test.check "1.1.1" :exclusions [org.clojure/clojure]]]}
+
              :cljfmt {:plugins [[lein-cljfmt "0.9.2" :exclusions [org.clojure/clojure
                                                                   org.clojure/clojurescript]]]}
              :eastwood {:plugins         [[jonase/eastwood "1.4.0"]]
-                        :eastwood {:add-linters [:performance :boxed-math]}}
+                        :eastwood {:add-linters [:performance :boxed-math]
+                                   :config-files ["eastwood.clj"]}}
              :clj-kondo {:dependencies [[clj-kondo "2023.05.26"]
                                         [com.fasterxml.jackson.core/jackson-core "2.14.2"]]}
              :deploy {:source-paths [".circleci/deploy"]}})

--- a/src/logjam/appender.clj
+++ b/src/logjam/appender.clj
@@ -1,0 +1,140 @@
+(ns logjam.appender
+  "A log appender that captures log events in memory."
+  {:author "r0man"}
+  (:require [logjam.event :as event]))
+
+(def ^:private default-size
+  "The default number of events captured by an appender."
+  100000)
+
+(def ^:private default-threshold
+  "The default threshold in percentage after which log events are cleaned up.
+
+  Events of a log appender are cleanup up if the number of events reach the
+  `default-size` plus the `default-threshold` percentage of
+  `default-threshold`."
+  10)
+
+(defn- garbage-collect?
+  "Whether to garbage collect events, or not."
+  [{:keys [event-index ^long size ^long threshold]}]
+  (> (count event-index)
+     (+ size (* size (/ threshold 100.0)))))
+
+(defn- garbage-collect-events
+  "Garbage collect some events of the `appender`."
+  [{:keys [events event-index size] :as appender}]
+  (if (garbage-collect? appender)
+    (assoc appender
+           :events (take size events)
+           :event-index (apply dissoc event-index (map :id (drop size events))))
+    appender))
+
+(defn- add-event?
+  "Whether the `event` should be added to the appender."
+  [{:keys [filter-fn]} event]
+  (or (nil? filter-fn) (filter-fn event)))
+
+(defn- notify-consumers
+  [{:keys [consumers] :as appender} event]
+  (doseq [{:keys [callback filter-fn] :as consumer} (vals consumers)
+          :when (filter-fn event)]
+    (callback consumer event))
+  appender)
+
+(defn- enqueue-event
+  "Enqueue the `event` to the event list of `appender`."
+  [appender event]
+  (update appender :events #(cons event %)))
+
+(defn- index-event
+  "Add the `event` to the index of `appender`."
+  [appender event]
+  (assoc-in appender [:event-index (:id event)] event))
+
+(defn add-consumer
+  "Add the `consumer` to the `appender`."
+  [appender {:keys [id filters] :as consumer}]
+  (assert (not (get-in appender [:consumers id]))
+          (format "Consumer %s already registered" id))
+  (assoc-in appender [:consumers id]
+            (-> (select-keys consumer [:callback :filters :id])
+                (assoc :filter-fn (event/search-filter (:levels appender) filters)))))
+
+(defn add-event
+  "Add the `event` to the `appender`."
+  [appender event]
+  (if (add-event? appender event)
+    (-> (enqueue-event appender event)
+        (index-event event)
+        (notify-consumers event)
+        (garbage-collect-events))
+    appender))
+
+(defn clear
+  "Clear the events from the `appender`."
+  [appender]
+  (assoc appender :events [] :event-index {}))
+
+(defn consumers
+  "Return the consumers of the `appender`."
+  [appender]
+  (vals (:consumers appender)))
+
+(defn consumer-by-id
+  "Find the consumer of `appender` by `id`."
+  [appender id]
+  (some #(and (= id (:id %)) %) (consumers appender)))
+
+(defn event
+  "Lookup the event by `id` from the log `appender`."
+  [appender id]
+  (get (:event-index appender) id))
+
+(defn events
+  "Return the events from the `appender`."
+  [appender]
+  (take (:size appender) (:events appender)))
+
+(defn make-appender
+  "Make a hash map appender."
+  [{:keys [id filters levels logger size threshold]}]
+  (cond-> {:consumers {}
+           :event-index {}
+           :events nil
+           :filters (or filters {})
+           :id id
+           :levels levels
+           :size (or size default-size)
+           :threshold (or threshold default-threshold)}
+    (map? filters)
+    (assoc :filter-fn (event/search-filter levels filters))
+    logger
+    (assoc :logger logger)))
+
+(defn remove-consumer
+  "Remove the `consumer` from the `appender`."
+  [appender consumer]
+  (update appender :consumers dissoc (:id consumer)))
+
+(defn update-appender
+  "Update the log `appender`."
+  [appender {:keys [filters size threshold]}]
+  (cond-> appender
+    (map? filters)
+    (assoc :filters filters :filter-fn (event/search-filter (:levels appender) filters))
+    (pos-int? size)
+    (assoc :size size)
+    (nat-int? threshold)
+    (assoc :threshold threshold)))
+
+(defn update-consumer
+  "Update the `consumer` of the `appender`."
+  [appender {:keys [id filters] :as consumer}]
+  (update-in appender [:consumers id]
+             (fn [existing-consumer]
+               (assert (:id existing-consumer)
+                       (format "Consumer %s not registered" id))
+               (-> existing-consumer
+                   (merge (select-keys consumer [:filters]))
+                   (assoc :filter-fn (event/search-filter (:levels appender) filters))))))

--- a/src/logjam/event.clj
+++ b/src/logjam/event.clj
@@ -1,0 +1,73 @@
+(ns logjam.event
+  "Log event related utilities like searching and calculating frequencies."
+  {:author "r0man"}
+  (:require [clojure.string :as str])
+  (:import [java.util.regex Pattern]))
+
+(defn- exception-name
+  "Return the `exception` class name."
+  [^Throwable exception]
+  (some-> exception .getClass .getName))
+
+(defn exception-frequencies
+  "Return the exception name frequencies of `events`."
+  [events]
+  (frequencies (keep #(some-> % :exception exception-name) events)))
+
+(defn logger-frequencies
+  "Return the logger name frequencies of `events`."
+  [events]
+  (frequencies (map :logger events)))
+
+(defn level-frequencies
+  "Return the log level frequencies of `events`."
+  [events]
+  (frequencies (map :level events)))
+
+(defn search-filter
+  "Return a predicate function that computes if a given event matches the search criteria."
+  [levels {:keys [end-time exceptions level loggers pattern start-time threads]}]
+  (let [exceptions (set exceptions)
+        level->weight (into {} (map (juxt :name :weight) levels))
+        level-weight (when (or (string? level) (keyword? level))
+                       (some-> level name str/upper-case keyword level->weight))
+        loggers (set loggers)
+        threads (set threads)
+        pattern (cond
+                  (string? pattern)
+                  (try (re-pattern pattern) (catch Exception _))
+                  (instance? Pattern pattern)
+                  pattern)]
+    (if (or (seq exceptions) (seq loggers) (seq threads) level-weight pattern start-time end-time)
+      (fn [event]
+        (and (or (empty? exceptions)
+                 (contains? exceptions (some-> event :exception exception-name)))
+             (or (nil? level-weight)
+                 (>= ^long (level->weight (:level event)) ^long level-weight))
+             (or (empty? loggers)
+                 (contains? loggers (:logger event)))
+             (or (empty? threads)
+                 (contains? threads (:thread event)))
+             (or (not pattern)
+                 (some->> event :message (re-matches pattern)))
+             (or (not (nat-int? start-time))
+                 (>= ^long (:timestamp event) ^long start-time))
+             (or (not (nat-int? end-time))
+                 (< ^long (:timestamp event) ^long end-time))))
+      (constantly true))))
+
+(defn search
+  "Search the log events by `criteria`."
+  [levels {:keys [filters limit offset] :as _criteria} events]
+  (cond->> events
+    (map? filters)
+    (filter (search-filter levels filters))
+    (nat-int? offset)
+    (drop offset)
+    true
+    (take (if (nat-int? limit) limit 500))))
+
+(defn thread-frequencies
+  "Return the thread frequencies of `events`."
+  [events]
+  (frequencies (map (comp name :thread) events)))

--- a/src/logjam/framework.clj
+++ b/src/logjam/framework.clj
@@ -1,0 +1,145 @@
+(ns logjam.framework
+  "A unified interface to capture and inspect log events of Java logging
+  frameworks."
+  {:author "r0man"}
+  (:require [logjam.appender :as appender]
+            [logjam.event :as event]))
+
+(def ^:dynamic *frameworks*
+  ['logjam.framework.logback/framework
+   'logjam.framework.jul/framework])
+
+(defn- ex-appender-not-found
+  "Return the appender not found exception info."
+  [framework appender]
+  (ex-info (format "Log appender %s not found in framework %s"
+                   (:id appender) (:id framework))
+           {:error :log-appender-not-found
+            :framework (:id framework)
+            :appender (:id appender)}))
+
+(defn find-appender!
+  "Find the `appender` by its :id key in `framework`, or throw an exception."
+  [framework appender]
+  (or (get-in framework [:appenders (:id appender)])
+      (throw (ex-appender-not-found framework appender))))
+
+(defn appenders
+  "Return the appenders of the log `framework`."
+  [framework]
+  (vals (:appenders framework)))
+
+(defn appender [framework appender]
+  (some #(and (= (:id appender) (:id (deref %))) %)
+        (appenders framework)))
+
+(defn add-appender
+  "Add the log `appender` to the `framework`."
+  [framework appender]
+  (let [atom-appender (atom (-> {:levels (:levels framework)
+                                 :logger (:root-logger framework)}
+                                (merge appender)
+                                (appender/make-appender)))]
+    (-> (assoc-in framework [:appenders (:id @atom-appender)] atom-appender)
+        ((:add-appender-fn framework) atom-appender))))
+
+(defn add-consumer
+  "Add `consumer` to the `appender` of the log `framework`."
+  [framework appender consumer]
+  (let [atom-appender (find-appender! framework appender)]
+    (swap! atom-appender appender/add-consumer consumer)
+    framework))
+
+(defn clear-appender
+  "Clear the log `appender` of the `framework`."
+  [framework appender]
+  (let [atom-appender (find-appender! framework appender)]
+    (swap! atom-appender appender/clear)
+    framework))
+
+(defn consumer
+  "Find the `consumer` listening to the `appender` of the log `framework`."
+  [framework appender consumer]
+  (let [atom-appender (find-appender! framework appender)]
+    (appender/consumer-by-id @atom-appender (:id consumer))))
+
+(defn event
+  "Lookup the event by `id` in the `appender` of the `framework`."
+  [framework appender id]
+  (let [atom-appender (find-appender! framework appender)]
+    (appender/event @atom-appender id)))
+
+(defn events
+  "Return the log events captured by the `appender` of the `framework`."
+  [framework appender]
+  (let [atom-appender (find-appender! framework appender)]
+    (appender/events @atom-appender)))
+
+(defn log
+  "Log the `event` with the `framework`."
+  [framework event]
+  ((:log-fn framework) framework event)
+  nil)
+
+(defn remove-appender
+  "Remove the log `appender` from the `framework`."
+  [framework appender]
+  (let [atom-appender (find-appender! framework appender)]
+    (-> ((:remove-appender-fn framework) framework atom-appender)
+        (update :appenders dissoc (:id @atom-appender)))))
+
+(defn remove-consumer
+  "Remove the `consumer` listening to the `appender` of the log `framework`."
+  [framework appender consumer]
+  (let [atom-appender (find-appender! framework appender)]
+    (swap! atom-appender appender/remove-consumer consumer)
+    framework))
+
+(defn update-appender
+  "Update the `appender` of the log `framework`."
+  [framework appender]
+  (let [atom-appender (find-appender! framework appender)]
+    (swap! atom-appender appender/update-appender appender)
+    framework))
+
+(defn update-consumer
+  "Update the `consumer` listening to the `appender` of the log `framework`."
+  [framework appender consumer]
+  (let [atom-appender (find-appender! framework appender)]
+    (swap! atom-appender appender/update-consumer consumer)
+    framework))
+
+(defn resolve-framework
+  "Resolve the framework bound to `framework-sym`."
+  [framework-sym]
+  (try (require (-> framework-sym namespace symbol))
+       (some-> framework-sym resolve deref)
+       (catch Exception _)))
+
+(defn resolve-frameworks
+  "Resolve the framework bound to `framework-syms`."
+  ([]
+   (resolve-frameworks *frameworks*))
+  ([framework-syms]
+   (reduce (fn [frameworks framework-sym]
+             (if-let [framework (resolve-framework framework-sym)]
+               (assoc frameworks (:id framework) framework)
+               frameworks))
+           {} framework-syms)))
+
+(defn search-events
+  "Search the log events captured by the `appender` of the log
+  `framework` and filter them by the search `criteria`."
+  [framework appender criteria]
+  (->> (events framework appender)
+       (event/search (:levels framework) criteria)))
+
+(defn shutdown
+  "Shutdown all consumers and appenders of the log `framework`."
+  [framework]
+  (reduce (fn [framework appender]
+            (-> (reduce (fn [framework consumer]
+                          (remove-consumer framework @appender consumer))
+                        framework (appender/consumers @appender))
+                (remove-appender @appender)))
+          framework (appenders framework)))

--- a/src/logjam/framework/jul.clj
+++ b/src/logjam/framework/jul.clj
@@ -1,0 +1,101 @@
+(ns logjam.framework.jul
+  "Log event capturing implementation for Java Util Logging."
+  {:author "r0man"}
+  (:require [clojure.set :as set]
+            [logjam.appender :as appender])
+  (:import (java.util.logging Level Logger LogRecord StreamHandler)))
+
+(def ^:private log-levels
+  "The Java Util Logging level descriptors."
+  (->> [{:name :FINEST
+         :category :trace
+         :object Level/FINEST}
+        {:name :FINER
+         :category :trace
+         :object Level/FINER}
+        {:name :FINE
+         :category :debug
+         :object Level/FINE}
+        {:name :CONFIG
+         :category :info
+         :object Level/CONFIG}
+        {:name :INFO
+         :category :info
+         :object Level/INFO}
+        {:name :WARNING
+         :category :warning
+         :object Level/WARNING}
+        {:name :SEVERE
+         :category :error
+         :object Level/SEVERE}]
+       (map-indexed #(assoc %2 :weight %1))))
+
+(def ^:private level-to-keyword
+  (into {} (map (juxt :object :name) log-levels)))
+
+(def ^:private keyword-to-level
+  (set/map-invert level-to-keyword))
+
+(defn- event->record
+  "Convert a logjam event into a Java LogRecord."
+  ^LogRecord [{:keys [arguments exception level logger message]}]
+  (doto (LogRecord. (keyword-to-level level Level/INFO) message)
+    (.setLoggerName (or logger ""))
+    (.setParameters (into-array Object arguments))
+    (.setThrown exception)))
+
+(defn- thread-by-id
+  "Find the thread by `id`."
+  ^Thread [id]
+  (some #(and (= id (.getId ^Thread %)) %)
+        (keys (Thread/getAllStackTraces))))
+
+(defn- record->event
+  "Convert a Java LogRecord into a logjam event."
+  [^LogRecord record]
+  (let [exception (.getThrown record)]
+    (cond-> {:arguments (vec (.getParameters record))
+             :id (java.util.UUID/randomUUID)
+             :level (level-to-keyword (.getLevel record))
+             :logger (.getLoggerName record)
+             :mdc {}
+             :message (.getMessage record)
+             :thread (some-> record .getThreadID thread-by-id .getName)
+             :timestamp (.getMillis record)}
+      exception (assoc :exception exception))))
+
+(defn- add-appender
+  "Attach the Logback appender."
+  [framework appender]
+  (let [instance (proxy [StreamHandler] []
+                   (publish [^LogRecord record]
+                     (swap! appender appender/add-event (record->event record))))
+        ^String logger-name (or (:logger appender) (:root-logger framework))]
+    (swap! appender assoc :instance instance)
+    (doto ^Logger (Logger/getLogger logger-name)
+      (.addHandler instance))
+    framework))
+
+(defn- remove-appender
+  "Remove `appender` from the Logback `framework`."
+  [framework appender]
+  (let [^String logger-name (or (:logger appender) (:root-logger framework))
+        logger (Logger/getLogger logger-name)]
+    (.removeHandler logger (:instance @appender))
+    framework))
+
+(defn- log [framework event]
+  (let [^String logger-name (or (:logger event) (:root-logger framework))]
+    (.log (Logger/getLogger logger-name) (event->record event))))
+
+(def framework
+  "The Java Util Logging framework."
+  {:add-appender-fn #'add-appender
+   :id "jul"
+   :javadoc-url "https://docs.oracle.com/en/java/javase/19/docs/api/java.logging/java/util/logging/package-summary.html"
+   :levels log-levels
+   :log-fn #'log
+   :name "Java Util Logging"
+   :remove-appender-fn #'remove-appender
+   :root-logger ""
+   :website-url "https://docs.oracle.com/en/java/javase/19/core/java-logging-overview.html"})

--- a/src/logjam/framework/logback.clj
+++ b/src/logjam/framework/logback.clj
@@ -1,0 +1,112 @@
+(ns logjam.framework.logback
+  "Log event capturing implementation for Logback."
+  {:author "r0man"}
+  (:require [clojure.set :as set]
+            [logjam.appender :as appender])
+  (:import (ch.qos.logback.classic Level Logger LoggerContext)
+           (ch.qos.logback.classic.spi ILoggingEvent LoggingEvent ThrowableProxy)
+           (ch.qos.logback.core Appender AppenderBase)
+           (org.slf4j LoggerFactory MarkerFactory MDC)))
+
+(def ^:private log-levels
+  "The Logback level descriptors."
+  (->> [{:name :TRACE
+         :category :trace
+         :object Level/TRACE}
+        {:name :DEBUG
+         :category :debug
+         :object Level/DEBUG}
+        {:name :INFO
+         :category :info
+         :object Level/INFO}
+        {:name :WARN
+         :category :warning
+         :object Level/WARN}
+        {:name :ERROR
+         :category :error
+         :object Level/ERROR}]
+       (map-indexed #(assoc %2 :weight %1))))
+
+(def ^:private level-to-keyword
+  (into {} (map (juxt :object :name) log-levels)))
+
+(def ^:private keyword-to-level
+  (set/map-invert level-to-keyword))
+
+(defn- logger-context
+  "Return the Logback logger context."
+  ^LoggerContext []
+  (LoggerFactory/getILoggerFactory))
+
+(defn- get-logger
+  "Return the logger by `name` from the logger `context`."
+  ^Logger [^String name]
+  (.getLogger (logger-context) name))
+
+(defn- event-exception [^LoggingEvent event]
+  (let [proxy (.getThrowableProxy event)]
+    (when (instance? ThrowableProxy proxy)
+      (.getThrowable ^ThrowableProxy proxy))))
+
+(defn- event-data [^LoggingEvent event]
+  (let [exception (event-exception event)]
+    (cond-> {:arguments (vec (.getArgumentArray event))
+             :id (java.util.UUID/randomUUID)
+             :level (level-to-keyword (.getLevel event))
+             :logger (.getLoggerName event)
+             :mdc (into {} (.getMDCPropertyMap event))
+             :message (.getFormattedMessage event)
+             :thread (.getThreadName event)
+             :timestamp (.getTimeStamp event)}
+      exception (assoc :exception exception))))
+
+(defn- add-appender
+  "Attach the Logback appender."
+  [framework appender]
+  (let [instance (doto (proxy [AppenderBase] []
+                         (append [^ILoggingEvent event]
+                           (swap! appender appender/add-event (event-data event))))
+                   (.setContext (logger-context))
+                   (.setName (:id @appender))
+                   (.start))]
+    (swap! appender assoc :instance instance)
+    (doto ^Logger (get-logger (or (:logger appender) (:root-logger framework)))
+      (.addAppender instance))
+    framework))
+
+(defn- level-int [level]
+  (some-> level keyword-to-level Level/toLocationAwareLoggerInteger))
+
+(defn- log [framework {:keys [arguments exception level logger marker mdc message]}]
+  (let [logger (get-logger (or logger (:root-logger framework)))]
+    (doseq [[key value] (seq mdc)]
+      (MDC/put key value))
+    (.log logger
+          (some-> marker MarkerFactory/getMarker)
+          ^String (.getName logger) ;;TODO: What is "fqcn"?
+          (level-int (or level :INFO))
+          message
+          (into-array Object arguments)
+          exception)
+    (when (seq mdc)
+      (MDC/clear))))
+
+(defn- remove-appender
+  "Remove `appender` from the Logback `framework`."
+  [framework appender]
+  (.stop ^Appender (:instance @appender))
+  (doto ^Logger (get-logger (or (:logger appender) (:root-logger framework)))
+    (.detachAppender ^String (:id @appender)))
+  framework)
+
+(def framework
+  "The Logback logging framework."
+  {:add-appender-fn #'add-appender
+   :id "logback"
+   :javadoc-url "https://logback.qos.ch/apidocs"
+   :levels log-levels
+   :log-fn #'log
+   :name "Logback"
+   :remove-appender-fn #'remove-appender
+   :root-logger Logger/ROOT_LOGGER_NAME
+   :website-url "https://logback.qos.ch"})

--- a/src/logjam/repl.clj
+++ b/src/logjam/repl.clj
@@ -1,0 +1,316 @@
+(ns ^{:clojure.tools.namespace.repl/unload false
+      :clojure.tools.namespace.repl/load false}
+ logjam.repl
+  "This namespace provide functionality to capture and search log events
+  emitted by Java logging frameworks. It is designed to be used by
+  non-NREPL users in a plain REPL.
+
+  Example usage:
+
+  ;; Use the :logback logging framework
+  (repl/set-framework! :logback)
+
+  ;; Add an appender to the log framework that captures events.
+  (repl/add-appender)
+
+  ;; Log something
+  (repl/log :message \"hello\")
+
+  ;; Return all captured log events
+  (repl/events)
+
+  ;; Search log events by message
+  (repl/events :pattern \"hell.*\")
+
+  ;; Search log events by level
+  (repl/events :level :INFO)
+
+  ;; Add a log consumer that prints log events
+  (repl/add-consumer
+    :callback (fn [_consumer event]
+                (clojure.pprint/pprint event)))
+
+  ;; Log something else
+  (repl/log :message \"world\")
+
+  ;; Remove all consumers and appenders
+  (repl/shutdown)"
+  (:require [clojure.pprint :as pprint]
+            [logjam.framework :as framework]))
+
+(defonce ^:dynamic *settings*
+  {:framework "jul"
+   :appender "default"
+   :consumer "default"})
+
+(defonce ^:dynamic *frameworks*
+  (framework/resolve-frameworks))
+
+(defn- merge-default [options]
+  (let [options (merge *settings* options)]
+    (cond-> options
+      (contains? options :appender)
+      (update :appender name)
+      (contains? options :consumer)
+      (update :consumer name)
+      (contains? options :framework)
+      (update :framework name))))
+
+(defn- appender-options [options]
+  (let [{:keys [appender filters logger size threshold]} (merge-default options)]
+    (cond-> {:id appender}
+      filters (assoc :filters filters)
+      logger (assoc :logger logger)
+      size (assoc :size size)
+      threshold (assoc :threshold threshold))))
+
+(defn- consumer-options [options]
+  (let [{:keys [callback consumer filters]} (merge-default options)]
+    (cond-> {:callback (or callback (fn [_ event] (pprint/pprint event)))}
+      consumer (assoc :id consumer)
+      filters (assoc :filters filters))))
+
+(defn- criteria
+  [{:keys [end-time exceptions level loggers pattern start-time threads]}]
+  {:filters (cond-> {}
+              (seq exceptions) (assoc :exceptions exceptions)
+              (seq loggers) (assoc :loggers loggers)
+              end-time (assoc :end-time end-time)
+              level (assoc :level level)
+              pattern (assoc :pattern pattern)
+              start-time (assoc :start-time start-time)
+              threads (assoc :threads threads))})
+
+(defn update-settings!
+  "Update the `*settings*` by applying `f` and `args` to it."
+  [f & args]
+  (alter-var-root #'*settings* #(apply f % args))
+  *settings*)
+
+;; Log Framework
+
+(defn- ensure-framework
+  "Ensure that the :framework in `options` is valid. Returns the
+  framework or throws an exception."
+  [options]
+  (let [{:keys [framework]} (merge-default options)]
+    (or (get *frameworks* (some-> framework name))
+        (throw (ex-info (str "Unsupported log framework: " framework)
+                        {:framework framework
+                         :supported-frameworks (keys *frameworks*)})))))
+
+(defn framework
+  "Lookup the current log framework or the one in `options`.
+
+  Options:
+    :framework - The identifier of the framework."
+  [& {:as options}]
+  (let [{:keys [framework]} (merge-default options)]
+    (get *frameworks* (some-> framework name))))
+
+(defn- swap-framework! [options f & args]
+  (let [framework (ensure-framework options)]
+    (alter-var-root #'*frameworks*
+                    (fn [frameworks]
+                      (update frameworks (:id framework) #(apply f % args))))
+    (get *frameworks* (:id framework))))
+
+(defn set-framework!
+  "Change the current framework to `identifier`."
+  [identifier]
+  (update-settings! assoc :framework (name identifier)))
+
+(defn shutdown
+  "Remove all consumers and appenders of a framework.
+
+  Options:
+    :framework - The identifier of the framework."
+  [& {:as options}]
+  (let [options (merge-default options)]
+    (swap-framework! options framework/shutdown)))
+
+;; Log Appender
+
+(defn- ensure-appender
+  "Ensure that the :appender in `options` is registered. Returns the
+  registered appender or throws an exception."
+  [options]
+  (let [{:keys [appender]} (merge-default options)
+        framework (ensure-framework options)]
+    (or (framework/appender framework {:id appender})
+        (throw (ex-info (str "Log appender not registered: " appender)
+                        {:appender appender
+                         :registered-appenders (->> (framework/appenders framework)
+                                                    (map (comp :id deref)))})))))
+
+(defn appenders
+  "Return all appenders of a log framework.
+
+  Options:
+    :framework - The identifier of the framework."
+  [& {:as options}]
+  (framework/appenders (ensure-framework options)))
+
+(defn appender
+  "Return the appender of a log framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender."
+  [& {:as options}]
+  (let [{:keys [appender]} (merge-default options)]
+    (framework/appender (ensure-framework options) {:id appender})))
+
+(defn add-appender
+  "Add a log appender to a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :filters - A map of criteria used to filter log events.
+    :logger - The name of the logger to which the append will be attached.
+    :size - The number of events to capture in the appender.
+    :threshold - A threshold in percentage used to garbage collect log events."
+  [& {:as options}]
+  (let [options (merge-default options)]
+    (-> (swap-framework! options framework/add-appender (appender-options options))
+        (framework/appender {:id (:appender options)}))))
+
+(defn clear-appender
+  "Clear the events captured by and appender of a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender."
+  [& {:as options}]
+  (swap-framework! options framework/clear-appender @(ensure-appender options)))
+
+(defn remove-appender
+  "Remove an appender from a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender."
+  [& {:as options}]
+  (swap-framework! options framework/remove-appender @(ensure-appender options)))
+
+(defn set-appender!
+  "Change the current appender to `identifier`."
+  [identifier]
+  (update-settings! assoc :appender (name identifier)))
+
+(defn update-appender
+  "Update the appender of a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :filters - A map of criteria used to filter log events.
+    :logger - The name of the logger to which the append will be attached.
+    :size - The number of events to capture in the appender.
+    :threshold - A threshold in percentage used to garbage collect log events."
+  [& {:as options}]
+  (ensure-appender options)
+  (swap-framework! options framework/update-appender (appender-options options)))
+
+;; Log Consumer
+
+(defn add-consumer
+  "Add a log consumer to a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :consumer - The identifier of the consumer.
+    :callback - A function that will be called for each log event.
+    :filters - A map of criteria used to filter log events."
+  [& {:as options}]
+  (swap-framework! options framework/add-consumer
+                   @(ensure-appender options)
+                   (consumer-options options)))
+
+(defn remove-consumer
+  "Remove a consumer from an appender.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :consumer - The identifier of the consumer."
+  [& {:as options}]
+  (let [{:keys [consumer]} (merge-default options)]
+    (swap-framework! options framework/remove-consumer
+                     @(ensure-appender options)
+                     {:id consumer})))
+
+(defn update-consumer
+  "Update the consumer of an appender.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :consumer - The identifier of the consumer.
+    :filters - A map of criteria used to filter log events."
+  [& {:as options}]
+  (let [options (merge-default options)]
+    (swap-framework! options framework/update-consumer
+                     @(ensure-appender options)
+                     (consumer-options options))))
+
+(defn set-consumer!
+  "Change the current consumer to `identifier`."
+  [identifier]
+  (update-settings! assoc :consumer (name identifier)))
+
+;; Log Event
+
+(defn event
+  "Find a log event captured by the an appender of a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :event - The identifier of the event."
+  [& {:as options}]
+  (when-let [event-id (:event options)]
+    (framework/event (ensure-framework options)
+                     @(ensure-appender options)
+                     event-id)))
+
+(defn events
+  "Search log events captured by an appender of a framework.
+
+  Options:
+    :framework - The identifier of the framework.
+    :appender - The identifier of the appender.
+    :end-time - Only include events before this timestamp.
+    :exceptions - Only include events matching the exception classes.
+    :level - Only include events with the given level.
+    :loggers - Only include events emitted by the loggers.
+    :pattern - Only include events whose message matches the regex pattern.
+    :start-time - Only include events after this timestamp.
+    :threads - Only include events emitted by the given threads."
+  [& {:as options}]
+  (framework/search-events (ensure-framework options)
+                           @(ensure-appender options)
+                           (criteria options)))
+
+(defn log
+  "Emit a log event.
+
+  Options:
+    :framework - The identifier of the framework.
+    :message - The message of the log event.
+    :mdc - The mapped diagnostic context of the log event.
+    :arguments - The arguments of the log event.
+    :level - The level of the log event.
+    :logger - The logger used to emit the log event."
+  [& {:as options}]
+  (let [options (merge-default options)]
+    (framework/log (ensure-framework options)
+                   (let [{:keys [arguments level logger message mdc]} options]
+                     (cond-> {}
+                       arguments (assoc :arguments arguments)
+                       level (assoc :level level)
+                       logger (assoc :logger logger)
+                       mdc (assoc :mdc mdc)
+                       message (assoc :message message))))))

--- a/test/logjam/appender_test.clj
+++ b/test/logjam/appender_test.clj
@@ -1,0 +1,56 @@
+(ns logjam.appender-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.properties :as prop]
+            [logjam.appender :as appender]))
+
+(def appender
+  (appender/make-appender {:id "my-appender" :levels []}))
+
+(defspec test-add-consumer
+  (prop/for-all
+   [events (s/gen (s/coll-of :logjam/event))]
+   (let [captured-events (atom [])
+         consumer {:id "my-consumer"
+                   :filters {}
+                   :callback #(swap! captured-events conj %2)}
+         appender (appender/add-consumer appender consumer)
+         appender (reduce appender/add-event appender events)]
+     (appender/remove-consumer appender consumer)
+     (= events @captured-events))))
+
+(defspec test-clear
+  (prop/for-all
+   [events (s/gen (s/coll-of :logjam/event))]
+   (-> (reduce appender/add-event appender events)
+       (appender/clear)
+       (appender/events)
+       (empty?))))
+
+(defspec test-event
+  (prop/for-all
+   [events (s/gen (s/coll-of :logjam/event))]
+   (let [appender (reduce appender/add-event appender events)]
+     (= (appender/events appender)
+        (map #(appender/event appender (:id %))
+             (appender/events appender))))))
+
+(defspec test-events
+  (prop/for-all
+   [events (s/gen (s/coll-of :logjam/event))]
+   (let [appender (reduce appender/add-event appender events)]
+     (= (take (:size appender) (reverse events))
+        (appender/events appender)))))
+
+(defspec test-remove-consumer
+  (prop/for-all
+   [events (s/gen (s/coll-of :logjam/event))]
+   (let [captured-events (atom [])
+         consumer {:id "my-consumer"
+                   :filters {}
+                   :callback #(swap! captured-events conj %2)}
+         appender (appender/add-consumer appender consumer)
+         appender (reduce appender/add-event appender events)
+         appender (appender/remove-consumer appender consumer)]
+     (doseq [event events] (appender/add-event appender event))
+     (= events @captured-events))))

--- a/test/logjam/event_test.clj
+++ b/test/logjam/event_test.clj
@@ -1,0 +1,83 @@
+(ns logjam.event-test
+  (:require [clojure.set :as set]
+            [clojure.spec.alpha :as s]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [logjam.event :as event]
+            [logjam.framework :as framework]
+            [logjam.test :as test]))
+
+(def frameworks
+  (vals (framework/resolve-frameworks)))
+
+(defspec test-search
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    criteria (s/gen :logjam.event/search)
+    events (s/gen (s/coll-of :logjam/event))]
+   (every? #(s/valid? :logjam/event %)
+           (event/search levels criteria events))))
+
+(defspec test-search-end-time
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    ^long end-time (s/gen :logjam.filter/end-time)
+    events (s/gen (s/coll-of :logjam/event))]
+   (every? #(< ^long (:timestamp %) end-time)
+           (event/search levels {:filters {:end-time end-time}} events))))
+
+(defspec test-search-exceptions
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    exceptions (s/gen :logjam.filter/exceptions)
+    events (s/gen (s/coll-of :logjam/event))]
+   (let [opts {:filters {:exceptions exceptions}}
+         events-found (event/search levels opts events)]
+     (set/subset? (set (map :exception events-found))
+                  (set (map :exception events))))))
+
+(defspec test-search-level
+  (prop/for-all
+   [[framework events criteria]
+    (gen/let [framework (gen/elements frameworks)
+              level (gen/one-of [(gen/elements (map :name (:levels framework)))])
+              events (gen/vector (test/event-gen framework) 3)]
+      [framework events {:filters {:level level}}])]
+   (let [level->weight (into {} (map (juxt :name :weight) (:levels framework)))
+         ^long min-weight (level->weight (-> criteria :filters :level))]
+     (every? #(>= ^long (level->weight (:level %)) min-weight)
+             (event/search (:levels framework) criteria events)))))
+
+(defspec test-search-loggers
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    loggers (s/gen :logjam.filter/loggers)
+    events (s/gen (s/coll-of :logjam/event))]
+   (let [opts {:filters {:loggers loggers}}
+         events-found (event/search levels opts events)]
+     (set/subset? (set (map :logger events-found))
+                  (set (map :logger events))))))
+
+(defspec test-search-limit
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    ^long limit (s/gen :logjam.pagination/limit)
+    events (s/gen (s/coll-of :logjam/event))]
+   (>= limit (count (event/search levels {:limit limit} events)))))
+
+(defspec test-search-offset
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    offset (s/gen :logjam.pagination/limit)
+    events (s/gen (s/coll-of :logjam/event))]
+   (= (drop offset events)
+      (event/search levels {:offset offset} events))))
+
+(defspec test-search-start-time
+  (prop/for-all
+   [{:keys [levels]} (gen/elements frameworks)
+    ^long start-time (s/gen :logjam.filter/start-time)
+    events (s/gen (s/coll-of :logjam/event))]
+   (every? #(>= ^long (:timestamp %) start-time)
+           (event/search levels {:filters {:start-time start-time}} events))))

--- a/test/logjam/framework_test.clj
+++ b/test/logjam/framework_test.clj
@@ -1,0 +1,57 @@
+(ns logjam.framework-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.test.check.generators :as gen]
+            [logjam.framework :as framework]
+            [logjam.framework.jul :as jul]
+            [logjam.framework.logback :as logback]
+            [logjam.specs]))
+
+(def appender
+  {:id "my-appender"})
+
+(def frameworks
+  [jul/framework logback/framework])
+
+(deftest test-add-appender
+  (doseq [framework frameworks]
+    (let [framework (framework/add-appender framework appender)]
+      (is (framework/appender framework appender))
+      (framework/remove-appender framework appender))))
+
+(deftest test-remove-appender
+  (doseq [framework frameworks]
+    (let [framework (-> (framework/add-appender framework appender)
+                        (framework/remove-appender appender))]
+      (is (nil? (framework/appender framework appender))))))
+
+(deftest test-log-levels
+  (doseq [framework frameworks]
+    (testing (:name framework)
+      (is (every? #(s/valid? :logjam/level %) (:levels framework))))))
+
+(deftest test-log-message
+  (doseq [framework frameworks]
+    (testing (:name framework)
+      (let [event (assoc (gen/generate (s/gen :logjam/event))
+                         :level :INFO
+                         :logger (:root-logger framework))
+            framework (framework/add-appender framework appender)]
+        (is (nil? (framework/log framework event)))
+        (let [events (framework/events framework appender)]
+          (is (= 1 (count events)))
+          (let [captured-event (first events)]
+            (is (= (:arguments event) (:arguments captured-event)))
+            (is (uuid? (:id captured-event)))
+            (is (= (:level event) (:level captured-event)))
+            (is (= (:logger event) (:logger captured-event)))
+            (is (= (case (keyword (:id framework))
+                     :jul {} ;; not supported
+                     :log4j2 (:mdc event)
+                     :logback (:mdc event))
+                   (:mdc captured-event)))
+            (is (= (:message event) (:message captured-event)))
+            (is (= (.getName (Thread/currentThread))
+                   (:thread captured-event)))
+            (is (pos-int? (:timestamp captured-event)))))
+        (framework/remove-appender framework appender)))))

--- a/test/logjam/repl_test.clj
+++ b/test/logjam/repl_test.clj
@@ -1,0 +1,158 @@
+(ns logjam.repl-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [logjam.framework :as framework]
+            [logjam.repl :as repl]
+            [logjam.specs])
+  (:import [java.util UUID]))
+
+(defn frameworks []
+  (vals (framework/resolve-frameworks)))
+
+(defmacro with-each-framework
+  "Evaluate `body` for each `framework` bound to `framework-sym`."
+  [[framework-sym frameworks] & body]
+  `(let [settings# repl/*settings*]
+     (doseq [framework# ~frameworks :let [~framework-sym framework#]]
+       (testing (format "Log framework %s" (:name framework#))
+         (repl/set-framework! (:id framework#))
+         (try ~@body
+              (finally
+                (repl/shutdown :framework (:id framework#))
+                (alter-var-root #'repl/*settings* (constantly settings#))))))))
+
+(deftest test-appender
+  (with-each-framework [_framework (frameworks)]
+    (testing "without any appenders"
+      (is (nil? (repl/appender))))
+    (testing "with an appender"
+      (repl/add-appender)
+      (is (= (:appender repl/*settings*)
+             (:id @(repl/appender)))))))
+
+(deftest test-appenders
+  (with-each-framework [_framework (frameworks)]
+    (testing "without any appenders"
+      (is (empty? (repl/appenders))))
+    (testing "with an appender"
+      (repl/add-appender)
+      (is (= [(repl/appender)] (repl/appenders))))))
+
+(deftest test-add-appender
+  (with-each-framework [_framework (frameworks)]
+    (is (repl/add-appender))
+    (is (= (:appender repl/*settings*)
+           (:id @(repl/appender))))))
+
+(deftest test-add-consumer
+  (with-each-framework [_framework (frameworks)]
+    (repl/add-appender)
+    (is (repl/add-consumer))))
+
+(deftest test-clear-appender
+  (with-each-framework [framework (frameworks)]
+    (let [level (-> framework :levels last :name)]
+      (repl/add-appender)
+      (repl/log :level level :message "1")
+      (repl/log :level level :message "2")
+      (is (= 2 (count (repl/events))))
+      (repl/clear-appender)
+      (is (= 0 (count (repl/events)))))))
+
+(deftest test-event
+  (with-each-framework [framework (frameworks)]
+    (let [events (atom [])
+          level (-> framework :levels last :name)]
+      (repl/add-appender)
+      (is (nil? (repl/event :event (UUID/randomUUID))))
+      (repl/add-consumer :callback (fn [_ event] (swap! events conj event)))
+      (repl/log :arguments [1 2 3]
+                :mdc {"a" "1"}
+                :level level
+                :logger (:root-logger framework)
+                :message "Hello World")
+      (is (= 1 (count @events)))
+      (let [event (first @events)]
+        (is (= event (repl/event :event (:id event))))))))
+
+(deftest test-events
+  (with-each-framework [framework (frameworks)]
+    (let [level (-> framework :levels last :name)]
+      (repl/add-appender)
+      (repl/log :level level :message "Hello World")
+      (repl/log :level level :message "Hello Moon")
+      (let [events  (repl/events :pattern ".*World")]
+        (is (= 1 (count events)))
+        (is (= "Hello World" (:message (first events))))))))
+
+(deftest test-framework
+  (testing "default framework"
+    (is (map? (repl/framework))))
+  (testing "unsupported framework"
+    (is (nil? (repl/framework :framework "unknown")))))
+
+(deftest test-log
+  (with-each-framework [framework (frameworks)]
+    (let [events (atom [])
+          level (-> framework :levels last :name)]
+      (repl/add-appender)
+      (repl/add-consumer :callback (fn [_ event] (swap! events conj event)))
+      (repl/log :arguments [1 2 3]
+                :mdc {"a" "1"}
+                :level level
+                :logger (:root-logger framework)
+                :message "Hello World")
+      (is (= 1 (count @events)))
+      (let [event (first @events)]
+        (is (= [1 2 3] (:arguments event)))
+        (is (= level (:level event)))
+        (when (contains? #{"logback"} (:id framework))
+          (is (= {"a" "1"} (:mdc event))))
+        (is (= "Hello World" (:message event)))
+        (is (pos-int? (:timestamp event)))
+        (is (string? (:thread event)))))))
+
+(deftest test-set-framework!
+  (with-each-framework [_framework (frameworks)]
+    (doseq [framework (keys repl/*frameworks*)]
+      (repl/set-framework! framework)
+      (is (= framework (:id (repl/framework)))))))
+
+(deftest test-remove-appender
+  (with-each-framework [_framework (frameworks)]
+    (testing "without any appenders"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Log appender not registered: default"
+                            (repl/remove-appender))))
+    (testing "with an appender"
+      (repl/add-appender)
+      (repl/appender)
+      (repl/remove-appender)
+      (is (not (repl/appender))))))
+
+(deftest test-remove-consumer
+  (with-each-framework [_framework (frameworks)]
+    (repl/add-appender)
+    (repl/add-consumer)
+    (is (repl/remove-consumer))))
+
+(deftest test-update-appender
+  (with-each-framework [_framework (frameworks)]
+    (repl/add-appender)
+    (is (repl/update-appender))))
+
+(deftest test-update-consumer
+  (with-each-framework [_framework (frameworks)]
+    (repl/add-appender)
+    (repl/add-consumer)
+    (is (repl/update-consumer))))
+
+(deftest test-shutdown
+  (with-each-framework [_framework (frameworks)]
+    (testing "without any appenders"
+      (is (= (:id (repl/framework))
+             (:id (repl/shutdown)))))
+    (testing "with an appender"
+      (repl/add-appender)
+      (is (= (:id (repl/framework))
+             (:id (repl/shutdown))))
+      (is (empty? (repl/appenders))))))

--- a/test/logjam/specs.clj
+++ b/test/logjam/specs.clj
@@ -1,0 +1,378 @@
+(ns logjam.specs
+  (:require [clojure.spec.alpha :as s]
+            [logjam.appender :as appender]
+            [logjam.framework :as framework]
+            [logjam.repl :as repl])
+  (:import [java.util.regex Pattern]))
+
+(s/def :logjam.level/category simple-keyword?)
+(s/def :logjam.level/name simple-keyword?)
+(s/def :logjam.level/object any?)
+(s/def :logjam.level/weight nat-int?)
+
+(s/def :logjam/level
+  (s/keys :req-un [:logjam.level/category
+                   :logjam.level/name
+                   :logjam.level/object
+                   :logjam.level/weight]))
+
+(s/def :logjam.filter/end-time pos-int?)
+
+(s/def :logjam.filter/exceptions
+  (s/coll-of string? :kind set?))
+
+(s/def :logjam.filter/level simple-keyword?)
+
+(s/def :logjam.filter/loggers
+  (s/coll-of string? :kind set?))
+
+(s/def :logjam.filter/pattern string?)
+(s/def :logjam.filter/start-time pos-int?)
+
+(s/def :logjam.filter/threads
+  (s/coll-of string? :kind set?))
+
+(s/def :logjam/filters
+  (s/keys :opt-un [:logjam.filter/end-time
+                   :logjam.filter/exceptions
+                   :logjam.filter/level
+                   :logjam.filter/loggers
+                   :logjam.filter/pattern
+                   :logjam.filter/start-time
+                   :logjam.filter/threads]))
+
+(s/def :logjam.pagination/limit nat-int?)
+(s/def :logjam.pagination/offset nat-int?)
+
+(s/def :logjam.event/search
+  (s/keys :opt-un [:logjam.pagination/limit
+                   :logjam.pagination/offset
+                   :logjam/filters]))
+
+(s/def :logjam.framework/add-appender-fn ifn?)
+(s/def :logjam.framework/id string?)
+(s/def :logjam.framework/javadoc-url string?)
+(s/def :logjam.framework/levels (s/coll-of :logjam/level))
+(s/def :logjam.framework/log-fn ifn?)
+(s/def :logjam.framework/name string?)
+(s/def :logjam.framework/remove-appender-fn ifn?)
+(s/def :logjam.framework/root-logger string?)
+(s/def :logjam.framework/website-url string?)
+
+(s/def :logjam/framework
+  (s/keys :req-un [:logjam.framework/add-appender-fn
+                   :logjam.framework/id
+                   :logjam.framework/javadoc-url
+                   :logjam.framework/levels
+                   :logjam.framework/log-fn
+                   :logjam.framework/name
+                   :logjam.framework/remove-appender-fn
+                   :logjam.framework/root-logger
+                   :logjam.framework/website-url]))
+
+(s/def :logjam.appender/id string?)
+(s/def :logjam.appender/levels (s/coll-of :logjam/level))
+(s/def :logjam.appender/logger string?)
+(s/def :logjam.appender/size pos-int?)
+(s/def :logjam.appender/threshold (s/and nat-int? #(< ^long % 100)))
+
+(s/def :logjam.appender/options
+  (s/keys :req-un [:logjam.appender/id]
+          :opt-un [:logjam.appender/levels
+                   :logjam.appender/logger
+                   :logjam.appender/size
+                   :logjam.appender/threshold]))
+
+(s/def :logjam/appender
+  #(instance? clojure.lang.Atom %))
+
+(s/def :logjam.consumer/callback ifn?)
+(s/def :logjam.consumer/filter (s/map-of string? any?))
+(s/def :logjam.consumer/id string?)
+
+(s/def :logjam/consumer
+  (s/keys :req-un [:logjam.consumer/id]
+          :opt-un [:logjam.consumer/callback
+                   :logjam.consumer/filter]))
+
+(s/def :logjam.event/argument any?)
+(s/def :logjam.event/arguments (s/coll-of :logjam.event/argument :kind vector?))
+(s/def :logjam.event/id uuid?)
+(s/def :logjam.event/level simple-keyword?)
+(s/def :logjam.event/logger string?)
+(s/def :logjam.event/mdc (s/map-of string? string?))
+(s/def :logjam.event/message string?)
+(s/def :logjam.event/thread string?)
+(s/def :logjam.event/timestamp pos-int?)
+
+(s/def :logjam/event
+  (s/keys :req-un [:logjam.event/arguments
+                   :logjam.event/id
+                   :logjam.event/level
+                   :logjam.event/logger
+                   :logjam.event/mdc
+                   :logjam.event/message
+                   :logjam.event/thread
+                   :logjam.event/timestamp]))
+
+;; logjam.framework
+
+(s/fdef framework/appender
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options)
+  :ret :logjam/appender)
+
+(s/fdef framework/appenders
+  :args (s/cat :framework :logjam/framework)
+  :ret (s/coll-of :logjam/appender))
+
+(s/fdef framework/add-appender
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options)
+  :ret :logjam/framework)
+
+(s/fdef framework/add-consumer
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options
+               :consumer :logjam/consumer)
+  :ret :logjam/framework)
+
+(s/fdef framework/clear-appender
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options)
+  :ret :logjam/framework)
+
+(s/fdef framework/consumer
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options
+               :consumer :logjam/consumer)
+  :ret (s/nilable :logjam/consumer))
+
+(s/fdef framework/event
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options
+               :id :logjam.event/id)
+  :ret (s/nilable :logjam/event))
+
+(s/fdef framework/events
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options)
+  :ret (s/coll-of :logjam/event))
+
+(s/fdef framework/log
+  :args (s/cat :framework :logjam/framework
+               :event map?)
+  :ret nil?)
+
+(s/fdef framework/remove-appender
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options)
+  :ret :logjam/framework)
+
+(s/fdef framework/remove-consumer
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options
+               :consumer :logjam/consumer)
+  :ret :logjam/framework)
+
+(s/fdef framework/update-appender
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options)
+  :ret :logjam/framework)
+
+(s/fdef framework/resolve-framework
+  :args (s/cat :framework-sym qualified-symbol?)
+  :ret (s/nilable :logjam/framework))
+
+(s/fdef framework/resolve-frameworks
+  :args (s/or :arity-0 (s/cat)
+              :arity-1 (s/cat :framework-syms (s/coll-of qualified-symbol?)))
+  :ret (s/map-of :logjam.framework/id :logjam/framework))
+
+(s/fdef framework/search-events
+  :args (s/cat :framework :logjam/framework
+               :appender :logjam.appender/options
+               :criteria map?)
+  :ret (s/coll-of :logjam/event))
+
+;; logjam.appender
+
+(s/fdef appender/add-consumer
+  :args (s/cat :appender :logjam.appender/options
+               :consumer :logjam/consumer)
+  :ret :logjam.appender/options)
+
+(s/fdef appender/add-event
+  :args (s/cat :appender :logjam.appender/options
+               :event :logjam/event)
+  :ret :logjam.appender/options)
+
+(s/fdef appender/clear
+  :args (s/cat :appender :logjam.appender/options)
+  :ret :logjam.appender/options)
+
+(s/fdef appender/consumers
+  :args (s/cat :appender :logjam.appender/options)
+  :ret (s/coll-of :logjam/consumer))
+
+(s/fdef appender/consumer-by-id
+  :args (s/cat :appender :logjam.appender/options
+               :id :logjam.consumer/id)
+  :ret (s/nilable :logjam/consumer))
+
+(s/fdef appender/event
+  :args (s/cat :appender :logjam.appender/options
+               :id :logjam.event/id)
+  :ret (s/nilable :logjam/event))
+
+(s/fdef appender/events
+  :args (s/cat :appender :logjam.appender/options)
+  :ret (s/coll-of :logjam/event))
+
+(s/fdef appender/make-appender
+  :args (s/cat :appender :logjam.appender/options)
+  :ret :logjam.appender/options)
+
+(s/fdef appender/remove-consumer
+  :args (s/cat :appender :logjam.appender/options
+               :consumer :logjam/consumer)
+  :ret :logjam.appender/options)
+
+(s/fdef appender/update-appender
+  :args (s/cat :appender :logjam.appender/options
+               :settings map?)
+  :ret :logjam.appender/options)
+
+(s/fdef appender/update-consumer
+  :args (s/cat :appender :logjam.appender/options
+               :consumer :logjam/consumer)
+  :ret :logjam.appender/options)
+
+;; logjam.repl
+
+(s/def :logjam.repl.option/appender
+  (s/nilable (s/or :string string? :keyword keyword?)))
+
+(s/def :logjam.repl.option/callback ifn?)
+
+(s/def :logjam.repl.option/consumer
+  (s/nilable (s/or :string string? :keyword keyword?)))
+
+(s/def :logjam.repl.option/exceptions
+  (s/nilable (s/coll-of string?)))
+
+(s/def :logjam.repl.option/event uuid?)
+
+(s/def :logjam.repl.option/filters
+  (s/nilable (s/map-of keyword? any?)))
+
+(s/def :logjam.repl.option/framework
+  (s/nilable (s/or :string string? :keyword keyword?)))
+
+(s/def :logjam.repl.option/logger
+  (s/nilable string?))
+
+(s/def :logjam.repl.option/loggers
+  (s/nilable (s/coll-of string?)))
+
+(s/def :logjam.repl.option/pattern
+  (s/nilable (s/or :string string? :regex #(instance? Pattern %))))
+
+(s/def :logjam.repl.option/size
+  (s/nilable pos-int?))
+
+(s/def :logjam.repl.option/threads
+  (s/nilable (s/coll-of string?)))
+
+(s/def :logjam.repl.option/threshold
+  (s/nilable (s/and nat-int? #(<= 0 % 100))))
+
+(s/fdef repl/add-appender
+  :args (s/keys* :opt-un [:logjam.repl.option/framework
+                          :logjam.repl.option/appender
+                          :logjam.repl.option/filters
+                          :logjam.repl.option/logger
+                          :logjam.repl.option/size
+                          :logjam.repl.option/threshold])
+  :ret :logjam/appender)
+
+(s/fdef repl/add-consumer
+  :args (s/keys* :opt-un [:logjam.repl.option/appender
+                          :logjam.repl.option/callback
+                          :logjam.repl.option/consumer
+                          :logjam.repl.option/filters
+                          :logjam.repl.option/framework])
+  :ret :logjam/framework)
+
+(s/fdef repl/appender
+  :args (s/keys* :opt-un [:logjam.repl.option/framework
+                          :logjam.repl.option/appender])
+  :ret (s/nilable :logjam/appender))
+
+(s/fdef repl/appenders
+  :args (s/keys* :opt-un [:logjam.repl.option/framework])
+  :ret (s/coll-of :logjam/appender))
+
+(s/fdef repl/clear-appender
+  :args (s/keys* :opt-un [:logjam.repl.option/framework
+                          :logjam.repl.option/appender])
+  :ret :logjam/framework)
+
+(s/fdef repl/event
+  :args (s/keys* :req-un [:logjam.repl.option/event]
+                 :opt-un [:logjam.repl.option/appender
+                          :logjam.repl.option/framework])
+  :ret :logjam/framework)
+
+(s/fdef repl/events
+  :args (s/keys* :opt-un [:logjam.repl.option/appender
+                          :logjam.repl.option/exceptions
+                          :logjam.repl.option/framework
+                          :logjam.repl.option/loggers
+                          :logjam.repl.option/pattern
+                          :logjam.repl.option/threads])
+  :ret :logjam/framework)
+
+(s/fdef repl/framework
+  :args (s/keys* :opt-un [:logjam.repl.option/framework])
+  :ret :logjam/framework)
+
+(s/fdef repl/remove-appender
+  :args (s/keys* :opt-un [:logjam.repl.option/framework
+                          :logjam.repl.option/appender])
+  :ret :logjam/framework)
+
+(s/fdef repl/remove-consumer
+  :args (s/keys* :opt-un [:logjam.repl.option/appender
+                          :logjam.repl.option/consumer
+                          :logjam.repl.option/framework])
+  :ret :logjam/framework)
+
+(s/fdef repl/set-appender!
+  :args (s/cat :framework (s/or :string string? :keyword keyword?))
+  :ret map?)
+
+(s/fdef repl/set-consumer!
+  :args (s/cat :consumer (s/or :string string? :keyword keyword?))
+  :ret map?)
+
+(s/fdef repl/shutdown
+  :args (s/keys* :opt-un [:logjam.repl.option/framework])
+  :ret :logjam/framework)
+
+(s/fdef repl/update-appender
+  :args (s/keys* :opt-un [:logjam.repl.option/framework
+                          :logjam.repl.option/appender
+                          :logjam.repl.option/filters
+                          :logjam.repl.option/logger
+                          :logjam.repl.option/size
+                          :logjam.repl.option/threshold])
+  :ret :logjam/framework)
+
+(s/fdef repl/update-consumer
+  :args (s/keys* :opt-un [:logjam.repl.option/appender
+                          :logjam.repl.option/callback
+                          :logjam.repl.option/consumer
+                          :logjam.repl.option/filters
+                          :logjam.repl.option/framework])
+  :ret :logjam/framework)

--- a/test/logjam/test.clj
+++ b/test/logjam/test.clj
@@ -1,0 +1,21 @@
+(ns logjam.test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test.check.generators :as gen]
+            [logjam.specs]))
+
+(stest/instrument)
+
+(defn- exception-gen []
+  (->> (gen/tuple gen/string-alphanumeric
+                  (gen/map gen/keyword gen/any-printable-equatable))
+       (gen/fmap (fn [[msg data]] (ex-info msg data)))))
+
+(defn event-gen [framework]
+  (->> (gen/tuple (s/gen :logjam/event)
+                  (gen/elements (:levels framework))
+                  (exception-gen))
+       (gen/fmap (fn [[event level exception]]
+                   (cond-> (assoc event :level (:name level))
+                     (= :error (:category level))
+                     (assoc :exception exception))))))

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration scan="true" scanPeriod="5 seconds">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd}T%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>OFF</level>
+    </filter>
+  </appender>
+
+  <root level="ALL">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/test/resources/logging.properties
+++ b/test/resources/logging.properties
@@ -1,0 +1,59 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers=java.util.logging.FileHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= ALL
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+com.xyz.foo.level = SEVERE


### PR DESCRIPTION
This PR adds the code that used to live in cider-nrepl.

- I removed the log4j2 code for now, since it is not working yet. I
  will push the experiments I did so far to the log4j2 branch

- I removed the Clojure 1.8 build target, because logjam uses Clojure
  Spec in it's tests. We don't ship the specs, so cider-nrepl should
  not be affected by this. I talked to @bbatsov about this and I think
  he is fine with this approach.