### PR TITLE
Introduce Timbre support

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -4,4 +4,5 @@
 ((clojure-mode
   (clojure-indent-style . :always-align)
   (indent-tabs-mode . nil)
-  (fill-column . 80)))
+  (fill-column . 80)
+  (cider-log-framework-name . "Timbre")))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master (unreleased)
+
+* Introduce Timbre compatibility.
+
+## 0.1.1 (2023-06-26)
+
+* Initial release
+  * `java.util.logging` (Java Logging API, JUL) -compatible
+  * Logback-compatible

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint: kondo cljfmt eastwood
 deploy: check-env
 	lein with-profile -user,-dev,+$(VERSION) deploy clojars
 
-# Usage: PROJECT_VERSION=3.2.1 make install
+# Usage: PROJECT_VERSION=0.1.1 make install
 # PROJECT_VERSION is needed because it's not computed dynamically.
 install: check-install-env
 	lein with-profile -user,-dev,+$(VERSION) install

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,11 @@ cljfmt-fix:
 eastwood:
 	lein with-profile -user,-dev,+$(VERSION),+test,+deploy,+eastwood eastwood
 
-kondo:
-	lein with-profile -dev,-dev,+$(VERSION),+test,+clj-kondo run -m clj-kondo.main --lint src test .circleci/deploy
+.make_kondo_prep: project.clj .clj-kondo/config.edn
+	lein with-profile -dev,+$(VERSION),+test,+clj-kondo,+deploy clj-kondo --copy-configs --dependencies --parallel --lint '$$classpath' > $@
+
+kondo: .make_kondo_prep clean
+	lein with-profile -dev,+$(VERSION),+test,+clj-kondo,+deploy clj-kondo
 
 repl: lein-repl
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ At the moment the following log frameworks are supported:
 
 - [Java Util Logging](https://docs.oracle.com/en/java/javase/19/core/java-logging-overview.html)
 - [Logback](https://logback.qos.ch)
+- [Timbre](https://github.com/taoensso/timbre)
 
 ### Log Appender
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ appenders to loggers, in order to capture events.
 
 At the moment the following log frameworks are supported:
 
-- [Java Util Logging](https://docs.oracle.com/en/java/javase/19/core/java-logging-overview.html)
+- [`java.util.logging` (Java Logging API, JUL)](https://docs.oracle.com/en/java/javase/19/core/java-logging-overview.html)
 - [Logback](https://logback.qos.ch)
 - [Timbre](https://github.com/taoensso/timbre)
 

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
                                     :sign-releases false}]]
   :profiles {:provided {:dependencies [;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
                                        [ch.qos.logback/logback-classic "1.3.7"]
+                                       [com.taoensso/timbre "6.3.1" :exclusions [org.clojure/clojure]]
                                        [org.clojure/clojure "1.11.1"]]}
 
              :dev {:plugins [[cider/cider-nrepl "0.44.0"]

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,8 @@
 
              :test {:jvm-opts ["-Djava.util.logging.config.file=test/resources/logging.properties"]
                     :resource-paths ["test/resources"]
-                    :dependencies [[org.clojure/test.check "1.1.1" :exclusions [org.clojure/clojure]]]}
+                    :dependencies [[nubank/matcher-combinators "3.8.8"]
+                                   [org.clojure/test.check "1.1.1" :exclusions [org.clojure/clojure]]]}
 
              :cljfmt {:plugins [[lein-cljfmt "0.9.2" :exclusions [org.clojure/clojure
                                                                   org.clojure/clojurescript]]]}

--- a/project.clj
+++ b/project.clj
@@ -44,6 +44,6 @@
              :eastwood {:plugins         [[jonase/eastwood "1.4.2"]]
                         :eastwood {:add-linters [:performance :boxed-math]
                                    :config-files ["eastwood.clj"]}}
-             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2023.10.20"]]
-                         :dependencies [[com.fasterxml.jackson.core/jackson-core "2.14.2"]]}
+             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2023.10.20" :exclusions [org.clojure/clojure]]
+                                   [com.fasterxml.jackson.core/jackson-core "2.14.2"]]}
              :deploy {:source-paths [".circleci/deploy"]}})

--- a/project.clj
+++ b/project.clj
@@ -44,6 +44,6 @@
              :eastwood {:plugins         [[jonase/eastwood "1.4.2"]]
                         :eastwood {:add-linters [:performance :boxed-math]
                                    :config-files ["eastwood.clj"]}}
-             :clj-kondo {:dependencies [[clj-kondo "2023.12.15"]
-                                        [com.fasterxml.jackson.core/jackson-core "2.14.2"]]}
+             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2023.10.20"]]
+                         :dependencies [[com.fasterxml.jackson.core/jackson-core "2.14.2"]]}
              :deploy {:source-paths [".circleci/deploy"]}})

--- a/src/logjam/event.clj
+++ b/src/logjam/event.clj
@@ -30,7 +30,9 @@
   (let [exceptions (set exceptions)
         level->weight (into {} (map (juxt :name :weight) levels))
         level-weight (when (or (string? level) (keyword? level))
-                       (some-> level name str/upper-case keyword level->weight))
+                       (or (some-> level name str/upper-case keyword level->weight)
+                           ;; Timbre doesn't use upper-case convention:
+                           (get level->weight level)))
         loggers (set loggers)
         threads (set threads)
         pattern (cond

--- a/src/logjam/framework.clj
+++ b/src/logjam/framework.clj
@@ -7,7 +7,8 @@
 
 (def ^:dynamic *frameworks*
   ['logjam.framework.logback/framework
-   'logjam.framework.jul/framework])
+   'logjam.framework.jul/framework
+   'logjam.framework.timbre/framework])
 
 (defn- ex-appender-not-found
   "Return the appender not found exception info."

--- a/src/logjam/framework/jul.clj
+++ b/src/logjam/framework/jul.clj
@@ -65,7 +65,7 @@
       exception (assoc :exception exception))))
 
 (defn- add-appender
-  "Attach the Logback appender."
+  "Attach the Java Util Logging appender."
   [framework appender]
   (let [instance (proxy [StreamHandler] []
                    (publish [^LogRecord record]
@@ -77,7 +77,7 @@
     framework))
 
 (defn- remove-appender
-  "Remove `appender` from the Logback `framework`."
+  "Remove `appender` from the Java Util Logging `framework`."
   [framework appender]
   (let [^String logger-name (or (:logger appender) (:root-logger framework))
         logger (Logger/getLogger logger-name)]

--- a/src/logjam/framework/jul.clj
+++ b/src/logjam/framework/jul.clj
@@ -1,12 +1,12 @@
 (ns logjam.framework.jul
-  "Log event capturing implementation for Java Util Logging."
+  "Log event capturing implementation for `java.util.logging` (Java Logging API, JUL)."
   {:author "r0man"}
   (:require [clojure.set :as set]
             [logjam.appender :as appender])
   (:import (java.util.logging Level Logger LogRecord StreamHandler)))
 
 (def ^:private log-levels
-  "The Java Util Logging level descriptors."
+  "The `java.util.logging` (Java Logging API, JUL) level descriptors."
   (->> [{:name :FINEST
          :category :trace
          :object Level/FINEST}
@@ -65,7 +65,7 @@
       exception (assoc :exception exception))))
 
 (defn- add-appender
-  "Attach the Java Util Logging appender."
+  "Attach the `java.util.logging` (Java Logging API, JUL) appender."
   [framework appender]
   (let [instance (proxy [StreamHandler] []
                    (publish [^LogRecord record]
@@ -77,7 +77,7 @@
     framework))
 
 (defn- remove-appender
-  "Remove `appender` from the Java Util Logging `framework`."
+  "Remove `appender` from the `java.util.logging` (Java Logging API, JUL) `framework`."
   [framework appender]
   (let [^String logger-name (or (:logger appender) (:root-logger framework))
         logger (Logger/getLogger logger-name)]
@@ -89,7 +89,7 @@
     (.log (Logger/getLogger logger-name) (event->record event))))
 
 (def framework
-  "The Java Util Logging framework."
+  "The `java.util.logging` (Java Logging API, JUL) framework."
   {:add-appender-fn #'add-appender
    :id "jul"
    :javadoc-url "https://docs.oracle.com/en/java/javase/19/docs/api/java.logging/java/util/logging/package-summary.html"

--- a/src/logjam/framework/timbre.clj
+++ b/src/logjam/framework/timbre.clj
@@ -40,10 +40,10 @@
            :mdc (or context {})}
     ?err (assoc :exception ?err)))
 
-(defn add-thread-info [data]
+(defn- add-thread-info [data]
   (assoc data :thread (.getName (Thread/currentThread))))
 
-(defn add-thread-info-var? [x]
+(defn- add-thread-info-var? [x]
   (and (var? x)
        (= {:name 'add-thread-info,
            :ns "logjam.framework.timbre"}

--- a/src/logjam/framework/timbre.clj
+++ b/src/logjam/framework/timbre.clj
@@ -1,5 +1,6 @@
 (ns logjam.framework.timbre
   "Log event capturing implementation for Timbre."
+  {:added "0.2.0"}
   (:require
    [logjam.appender :as appender]
    [taoensso.timbre :as timbre])

--- a/src/logjam/framework/timbre.clj
+++ b/src/logjam/framework/timbre.clj
@@ -1,0 +1,94 @@
+(ns logjam.framework.timbre
+  "Log event capturing implementation for Timbre."
+  (:require
+   [logjam.appender :as appender]
+   [taoensso.timbre :as timbre])
+  (:import
+   (java.util Date)))
+
+(def ^:private log-levels
+  "The Timbre level descriptors."
+  (->> [:trace :debug :info :warn :error :fatal :report]
+       (map-indexed #(assoc {:name %2
+                             :category %2
+                             :object %2}
+                            :weight %1))))
+
+(defn- extract-event-data [{:keys [vargs level appender-id msg_ ^Date instant context ^Throwable ?err thread]}]
+  (cond-> {:arguments vargs ;; `vargs` are the arguments passed to a errorf, infof, etc call
+           :id (java.util.UUID/randomUUID)
+           :level level
+           :logger appender-id
+           :message (or (not-empty @msg_)
+                        (some-> ?err .getMessage))
+           :thread (or thread
+                       (.getName (Thread/currentThread)))
+           :timestamp (some-> instant .getTime)
+           :mdc (or context {})}
+    ?err (assoc :exception ?err)))
+
+(defn add-thread-info [data]
+  (assoc data :thread (.getName (Thread/currentThread))))
+
+(defn add-thread-info-var? [x]
+  (and (var? x)
+       (= {:name 'add-thread-info,
+           :ns "logjam.framework.timbre"}
+          (-> x
+              meta
+              (select-keys [:name :ns])
+              (update :ns str)))))
+
+(defn- add-appender
+  "Attach the Timbre appender."
+  [framework appender]
+  (let [appender-id (:id @appender)
+        f {:enabled? true
+           :output-opts {:stacktrace-fonts {}}
+           :fn (fn [event-data]
+                 (swap! appender appender/add-event (extract-event-data event-data)))}]
+    (assert appender-id)
+    (timbre/merge-config! {:appenders {appender-id f}
+                           :middleware (->> timbre/*config*
+                                            :middleware
+                                            (remove add-thread-info-var?)
+                                            (into [#'add-thread-info]))})
+    (swap! appender assoc :instance f)
+    framework))
+
+(defn- log [_framework {:keys [arguments exception level message mdc]}]
+  (timbre/with-context (or mdc {})
+    (let [msg+ex (into []
+                       (remove nil?)
+                       [(not-empty message), exception])
+          format? (seq arguments)
+          vargs (if format?
+                  (into msg+ex arguments)
+                  msg+ex)]
+      (if format?
+        (timbre/log! {:level level :msg-type :f :vargs vargs})
+        (timbre/log! {:level level :msg-type :p :vargs vargs})))))
+
+(defn- remove-appender
+  "Remove `appender` from the Timbre`framework`."
+  [framework appender]
+  (let [appender-id (:id @appender)]
+    (assert appender-id)
+    (timbre/merge-config! {:appenders {appender-id nil}
+                           :middleware (->> timbre/*config*
+                                            :middleware
+                                            (remove add-thread-info-var?)
+                                            (into []))}))
+  framework)
+
+(def framework
+  "Timbre: Pure Clojure/Script logging library."
+  {:add-appender-fn #'add-appender
+   :id "timbre"
+   :javadoc-url "https://github.com/taoensso/timbre"
+   :levels log-levels
+   :log-fn #'log
+   :name "Timbre"
+   :remove-appender-fn #'remove-appender
+   :root-logger "cider-log-timbre-root-logger"
+   :website-url "https://github.com/taoensso/timbre"})

--- a/test/logjam/framework/timbre_test.clj
+++ b/test/logjam/framework/timbre_test.clj
@@ -1,0 +1,36 @@
+(ns logjam.framework.timbre-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [logjam.framework :as framework]
+   [logjam.framework.timbre :as sut]
+   [taoensso.timbre :as timbre]))
+
+;; for `match?`
+(require 'matcher-combinators.test)
+
+(def appender-map {:id (str `timbre)})
+
+(def ^:dynamic *framework* nil)
+
+(use-fixtures :each (fn with-timbre-framework [t]
+                      (binding [*framework* (framework/add-appender sut/framework appender-map)]
+                        (try
+                          (t)
+                          (finally
+                            (framework/remove-appender *framework* appender-map))))))
+
+(defn last-event []
+  (last (framework/events *framework* appender-map)))
+
+(deftest timbre-test
+  (testing "Basic case"
+    (timbre/info "sample")
+    (is (match? {:arguments ["sample"],
+                 :mdc {},
+                 :level :info,
+                 :thread (.getName (Thread/currentThread))
+                 :id uuid?,
+                 :logger "logjam.framework.timbre-test:27:5",
+                 :timestamp nat-int?,
+                 :message "sample"}
+                (last-event)))))

--- a/test/logjam/framework_test.clj
+++ b/test/logjam/framework_test.clj
@@ -45,9 +45,6 @@
                                 :logger (:root-logger framework))
               format? (seq (:arguments base-event))
               event (cond-> base-event
-                      timbre?
-                      (assoc :logger (:id appender))
-
                       (and timbre? format?)
                       (assoc :message (apply str "foo" (repeat (count (:arguments base-event))
                                                                " %s"))))
@@ -61,7 +58,8 @@
                 (is (= (:arguments event) (:arguments captured-event))))
               (is (uuid? (:id captured-event)))
               (is (= (:level event) (:level captured-event)))
-              (is (= (:logger event) (:logger captured-event)))
+              (when-not timbre? ;; timbre uses ns strings instead of logger ids
+                (is (= (:logger event) (:logger captured-event))))
               (is (= (case (keyword (:id framework))
                        :jul {} ;; not supported
                        :log4j2 (:mdc event)

--- a/test/logjam/framework_test.clj
+++ b/test/logjam/framework_test.clj
@@ -1,17 +1,20 @@
 (ns logjam.framework-test
-  (:require [clojure.spec.alpha :as s]
-            [clojure.test :refer [deftest is testing]]
-            [clojure.test.check.generators :as gen]
-            [logjam.framework :as framework]
-            [logjam.framework.jul :as jul]
-            [logjam.framework.logback :as logback]
-            [logjam.specs]))
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.test :refer [deftest is testing]]
+   [clojure.test.check.generators :as gen]
+   [logjam.framework :as framework]
+   [logjam.framework.jul :as jul]
+   [logjam.framework.logback :as logback]
+   [logjam.framework.timbre :as timbre]
+   [logjam.specs]
+   [taoensso.encore :as encore]))
 
 (def appender
   {:id "my-appender"})
 
 (def frameworks
-  [jul/framework logback/framework])
+  [jul/framework logback/framework timbre/framework])
 
 (deftest test-add-appender
   (doseq [framework frameworks]
@@ -33,25 +36,43 @@
 (deftest test-log-message
   (doseq [framework frameworks]
     (testing (:name framework)
-      (let [event (assoc (gen/generate (s/gen :logjam/event))
-                         :level :INFO
-                         :logger (:root-logger framework))
-            framework (framework/add-appender framework appender)]
-        (is (nil? (framework/log framework event)))
-        (let [events (framework/events framework appender)]
-          (is (= 1 (count events)))
-          (let [captured-event (first events)]
-            (is (= (:arguments event) (:arguments captured-event)))
-            (is (uuid? (:id captured-event)))
-            (is (= (:level event) (:level captured-event)))
-            (is (= (:logger event) (:logger captured-event)))
-            (is (= (case (keyword (:id framework))
-                     :jul {} ;; not supported
-                     :log4j2 (:mdc event)
-                     :logback (:mdc event))
-                   (:mdc captured-event)))
-            (is (= (:message event) (:message captured-event)))
-            (is (= (.getName (Thread/currentThread))
-                   (:thread captured-event)))
-            (is (pos-int? (:timestamp captured-event)))))
-        (framework/remove-appender framework appender)))))
+      (dotimes [_ 300] ;; b/c generative testing
+        (let [timbre? (= "timbre" (:id framework))
+              base-event (assoc (gen/generate (s/gen :logjam/event))
+                                :level (case (keyword (:id framework))
+                                         :timbre :info
+                                         :INFO)
+                                :logger (:root-logger framework))
+              format? (seq (:arguments base-event))
+              event (cond-> base-event
+                      timbre?
+                      (assoc :logger (:id appender))
+
+                      (and timbre? format?)
+                      (assoc :message (apply str "foo" (repeat (count (:arguments base-event))
+                                                               " %s"))))
+              framework (framework/add-appender framework appender)]
+          (is (nil? (framework/log framework event)))
+          (let [events (framework/events framework appender)]
+            (is (= 1 (count events)))
+            (let [captured-event (first events)]
+              (when (or (not timbre?)
+                        format?)
+                (is (= (:arguments event) (:arguments captured-event))))
+              (is (uuid? (:id captured-event)))
+              (is (= (:level event) (:level captured-event)))
+              (is (= (:logger event) (:logger captured-event)))
+              (is (= (case (keyword (:id framework))
+                       :jul {} ;; not supported
+                       :log4j2 (:mdc event)
+                       :logback (:mdc event)
+                       :timbre (:mdc event))
+                     (:mdc captured-event)))
+              (if format?
+                (is (= (:message captured-event) ;; nil
+                       (encore/format* (:message event) (:arguments event))))
+                (is (= (:message event) (:message captured-event))))
+              (is (= (.getName (Thread/currentThread))
+                     (:thread captured-event)))
+              (is (pos-int? (:timestamp captured-event)))))
+          (framework/remove-appender framework appender))))))

--- a/test/logjam/specs.clj
+++ b/test/logjam/specs.clj
@@ -1,9 +1,12 @@
 (ns logjam.specs
-  (:require [clojure.spec.alpha :as s]
-            [logjam.appender :as appender]
-            [logjam.framework :as framework]
-            [logjam.repl :as repl])
-  (:import [java.util.regex Pattern]))
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.string :as string]
+   [logjam.appender :as appender]
+   [logjam.framework :as framework]
+   [logjam.repl :as repl])
+  (:import
+   (java.util.regex Pattern)))
 
 (s/def :logjam.level/category simple-keyword?)
 (s/def :logjam.level/name simple-keyword?)
@@ -41,8 +44,8 @@
                    :logjam.filter/start-time
                    :logjam.filter/threads]))
 
-(s/def :logjam.pagination/limit nat-int?)
-(s/def :logjam.pagination/offset nat-int?)
+(s/def :logjam.pagination/limit (s/and nat-int? #(< ^long % 100)))
+(s/def :logjam.pagination/offset (s/and nat-int? #(< ^long % 100)))
 
 (s/def :logjam.event/search
   (s/keys :opt-un [:logjam.pagination/limit
@@ -101,7 +104,7 @@
 (s/def :logjam.event/level simple-keyword?)
 (s/def :logjam.event/logger string?)
 (s/def :logjam.event/mdc (s/map-of string? string?))
-(s/def :logjam.event/message string?)
+(s/def :logjam.event/message (s/and string? (complement string/blank?)))
 (s/def :logjam.event/thread string?)
 (s/def :logjam.event/timestamp pos-int?)
 

--- a/test/logjam/specs.clj
+++ b/test/logjam/specs.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.string :as string]
+   [clojure.test.check.generators :as gen]
    [logjam.appender :as appender]
    [logjam.framework :as framework]
    [logjam.repl :as repl])
@@ -103,7 +104,9 @@
 (s/def :logjam.event/id uuid?)
 (s/def :logjam.event/level simple-keyword?)
 (s/def :logjam.event/logger string?)
-(s/def :logjam.event/mdc (s/map-of string? string?))
+(s/def :logjam.event/mdc
+  (s/with-gen map? ;; relaxed spec for Timbre
+    #(s/gen (s/map-of string? string?)))) ;; strict gen for Logback
 (s/def :logjam.event/message (s/and string? (complement string/blank?)))
 (s/def :logjam.event/thread string?)
 (s/def :logjam.event/timestamp pos-int?)

--- a/test/logjam/specs.clj
+++ b/test/logjam/specs.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.string :as string]
-   [clojure.test.check.generators :as gen]
    [logjam.appender :as appender]
    [logjam.framework :as framework]
    [logjam.repl :as repl])


### PR DESCRIPTION
> Closes https://github.com/clojure-emacs/logjam/issues/8

Introduces Timbre support.

I verified it works, including misc features like `format`-ted messages, passing exceptions instead / in addition to messages, honoring Timbre `context`s, etc.

![image](https://github.com/clojure-emacs/logjam/assets/1162994/b70e530d-46b6-4c51-9f1b-587cf3e11fe1)
