### PR TITLE
Introduce `logjam.appender.default-event-size` configuration option

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Introduce `logjam.appender.default-event-size` configuration option.
+
 ## 0.2.0 (2024-01-04)
 
 * [#8](https://github.com/clojure-emacs/logjam/issues/8): Introduce Timbre compatibility.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ like:
 (repl/shutdown)
 ```
 
+## Configuration options
+
+The following options can be set as Java system properties:
+
+* `logjam.appender.default-event-size`
+  * The default maximum number of events that can be captured by a given appender.
+  * Default: 100000
+
 ## Development
 
 #### Makefile

--- a/src/logjam/appender.clj
+++ b/src/logjam/appender.clj
@@ -4,8 +4,9 @@
   (:require [logjam.event :as event]))
 
 (def ^:private default-size
-  "The default number of events captured by an appender."
-  100000)
+  "The default maximum number of events that can be captured by a given appender."
+  (or (some-> (System/getProperty "logjam.appender.default-event-size") Long/parseLong)
+      100000))
 
 (def ^:private default-threshold
   "The default threshold in percentage after which log events are cleaned up.


### PR DESCRIPTION
I think that personally I'll want a rather low maximum, say 1000 max, for usability.

But I have no particular opinion on what the right default size should be.

The use of system properties seems nice as it's a pretty universal mechanism, that is there at JVM startup (which is useful in the context of logging).

In a future we could have more settings exposed as system properties.

Maybe we could even tell logjam to create a framework+appender at JVM startup - would seem nicely declarative.

Cheers - V