### PR TITLE
Event filters: introduce `:loggers-blocklist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Introduce `logjam.appender.default-event-size` configuration option.
 
+* Event filters: rename `:loggers` to `:loggers-allowlist`
+ * `:loggers` will remain supported.
+
 ## 0.2.0 (2024-01-04)
 
 * [#8](https://github.com/clojure-emacs/logjam/issues/8): Introduce Timbre compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Introduce `logjam.appender.default-event-size` configuration option.
 
 * Event filters: rename `:loggers` to `:loggers-allowlist`
+* [#13](https://github.com/clojure-emacs/logjam/issues/13): Event filters: introduce `:loggers-blocklist`.
+* Event filters: rename `:loggers` to `:loggers-allowlist`.
  * `:loggers` will remain supported.
 
 ## 0.2.0 (2024-01-04)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ certain events.
 Log events can be searched, streamed to a client or viewed in CIDER's
 Inspector and Stacktrace Mode. When searching log events the user can
 specify a set of filters. Events that match the filters are shown in
-the `+*cider-log*+` buffer. Additionally a log consumer will be
+the `*cider-log*` buffer. Additionally a log consumer will be
 attached to the appender to receive log events matching the search
 criteria after the search command has been issued. The log appender
 will be removed automatically once a new search has been submitted or
@@ -70,6 +70,15 @@ Filters for log events can be attached to log appenders and
 consumers. They also take effect when searching events or streaming
 them to clients. If multiple filters are chosen they are combined
 using logical AND condition. The following filters are available:
+
+* `exceptions`
+* `level`
+* `pattern`
+* `start-time`
+* `end-time`
+* `threads`
+* `loggers-allowlist`
+* `loggers-blocklist`
 
 ## Usage
 

--- a/src/logjam/event.clj
+++ b/src/logjam/event.clj
@@ -26,7 +26,7 @@
 
 (defn search-filter
   "Return a predicate function that computes if a given event matches the search criteria."
-  [levels {:keys [end-time exceptions level pattern start-time threads loggers loggers-allowlist]}]
+  [levels {:keys [end-time exceptions level pattern start-time threads loggers loggers-allowlist loggers-blocklist]}]
   (let [exceptions (set exceptions)
         level->weight (into {} (map (juxt :name :weight) levels))
         level-weight (when (or (string? level) (keyword? level))
@@ -37,22 +37,25 @@
                  (set loggers) ;; legacy name
                  (set loggers-allowlist) ;; newer name (same semantics)
                  )
+        loggers-blocklist (set loggers-blocklist)
         threads (set threads)
         pattern (cond
                   (string? pattern)
                   (try (re-pattern pattern) (catch Exception _))
                   (instance? Pattern pattern)
                   pattern)]
-    (if (or (seq exceptions) (seq loggers) (seq threads) level-weight pattern start-time end-time)
+    (if (or (seq exceptions) (seq loggers) (seq loggers-blocklist) (seq threads) level-weight pattern start-time end-time)
       (fn [event]
-        (and (or (empty? exceptions)
-                 (contains? exceptions (some-> event :exception exception-name)))
-             (or (nil? level-weight)
-                 (>= ^long (level->weight (:level event)) ^long level-weight))
+        (and (or (empty? loggers-blocklist)
+                 (not (contains? loggers-blocklist (:logger event))))
              (or (empty? loggers)
                  (contains? loggers (:logger event)))
              (or (empty? threads)
                  (contains? threads (:thread event)))
+             (or (empty? exceptions)
+                 (contains? exceptions (some-> event :exception exception-name)))
+             (or (nil? level-weight)
+                 (>= ^long (level->weight (:level event)) ^long level-weight))
              (or (not pattern)
                  (some->> event :message (re-matches pattern)))
              (or (not (nat-int? start-time))

--- a/src/logjam/event.clj
+++ b/src/logjam/event.clj
@@ -26,14 +26,17 @@
 
 (defn search-filter
   "Return a predicate function that computes if a given event matches the search criteria."
-  [levels {:keys [end-time exceptions level loggers pattern start-time threads]}]
+  [levels {:keys [end-time exceptions level pattern start-time threads loggers loggers-allowlist]}]
   (let [exceptions (set exceptions)
         level->weight (into {} (map (juxt :name :weight) levels))
         level-weight (when (or (string? level) (keyword? level))
                        (or (some-> level name str/upper-case keyword level->weight)
                            ;; Timbre doesn't use upper-case convention:
                            (get level->weight level)))
-        loggers (set loggers)
+        loggers (into ;; The legacy `loggers` and the newer `loggers-allowlist` are combined, so as to not have breaking changes.
+                 (set loggers) ;; legacy name
+                 (set loggers-allowlist) ;; newer name (same semantics)
+                 )
         threads (set threads)
         pattern (cond
                   (string? pattern)

--- a/test/logjam/event_test.clj
+++ b/test/logjam/event_test.clj
@@ -1,6 +1,7 @@
 (ns logjam.event-test
   (:require [clojure.set :as set]
             [clojure.spec.alpha :as s]
+            [clojure.test :refer [testing]]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
@@ -50,14 +51,25 @@
              (event/search (:levels framework) criteria events)))))
 
 (defspec test-search-loggers
-  (prop/for-all
-   [{:keys [levels]} (gen/elements frameworks)
-    loggers (s/gen :logjam.filter/loggers)
-    events (s/gen (s/coll-of :logjam/event))]
-   (let [opts {:filters {:loggers loggers}}
-         events-found (event/search levels opts events)]
-     (set/subset? (set (map :logger events-found))
-                  (set (map :logger events))))))
+  (testing "`:loggers` (legacy key)"
+    (prop/for-all
+     [{:keys [levels]} (gen/elements frameworks)
+      loggers (s/gen :logjam.filter/loggers)
+      events (s/gen (s/coll-of :logjam/event))]
+     (let [opts {:filters {:loggers loggers}}
+           events-found (event/search levels opts events)]
+       (set/subset? (set (map :logger events-found))
+                    (set (map :logger events))))))
+
+  (testing "`:loggers-allowlist` (newer key)"
+    (prop/for-all
+     [{:keys [levels]} (gen/elements frameworks)
+      loggers (s/gen :logjam.filter/loggers-allowlist)
+      events (s/gen (s/coll-of :logjam/event))]
+     (let [opts {:filters {:loggers-allowlist loggers}}
+           events-found (event/search levels opts events)]
+       (set/subset? (set (map :logger events-found))
+                    (set (map :logger events)))))))
 
 (defspec test-search-limit
   (prop/for-all

--- a/test/logjam/event_test.clj
+++ b/test/logjam/event_test.clj
@@ -59,8 +59,9 @@
      (let [opts {:filters {:loggers loggers}}
            events-found (event/search levels opts events)]
        (set/subset? (set (map :logger events-found))
-                    (set (map :logger events))))))
+                    (set (map :logger events)))))))
 
+(defspec test-search-loggers-allowlist
   (testing "`:loggers-allowlist` (newer key)"
     (prop/for-all
      [{:keys [levels]} (gen/elements frameworks)
@@ -70,6 +71,18 @@
            events-found (event/search levels opts events)]
        (set/subset? (set (map :logger events-found))
                     (set (map :logger events)))))))
+
+(defspec test-search-loggers-blocklist
+  (testing "`:loggers-blocklist`"
+    (prop/for-all
+     [[events framework] (gen/let [framework (gen/elements frameworks)
+                                   events (gen/vector (test/event-gen framework) 10)]
+                           [events framework])]
+     (let [blocklist (->> events (take 5) (map :logger))
+           opts {:filters {:loggers-blocklist blocklist}}
+           events-found (event/search (:levels framework) opts events)]
+       (not-any? (set blocklist)
+                 (map :logger events-found))))))
 
 (defspec test-search-limit
   (prop/for-all

--- a/test/logjam/specs.clj
+++ b/test/logjam/specs.clj
@@ -31,6 +31,8 @@
 
 (s/def :logjam.filter/loggers-allowlist :logjam.filter/loggers)
 
+(s/def :logjam.filter/loggers-blocklist :logjam.filter/loggers)
+
 (s/def :logjam.filter/pattern string?)
 (s/def :logjam.filter/start-time pos-int?)
 
@@ -43,6 +45,7 @@
                    :logjam.filter/level
                    :logjam.filter/loggers
                    :logjam.filter/loggers-allowlist
+                   :logjam.filter/loggers-blocklist
                    :logjam.filter/pattern
                    :logjam.filter/start-time
                    :logjam.filter/threads]))
@@ -105,7 +108,8 @@
 (s/def :logjam.event/arguments (s/coll-of :logjam.event/argument :kind vector?))
 (s/def :logjam.event/id uuid?)
 (s/def :logjam.event/level simple-keyword?)
-(s/def :logjam.event/logger string?)
+(s/def :logjam.event/logger (s/with-gen string?
+                              #(s/gen (s/and string? (complement string/blank?)))))
 (s/def :logjam.event/mdc
   (s/with-gen map? ;; relaxed spec for Timbre
     #(s/gen (s/map-of string? string?)))) ;; strict gen for Logback

--- a/test/logjam/specs.clj
+++ b/test/logjam/specs.clj
@@ -29,6 +29,8 @@
 (s/def :logjam.filter/loggers
   (s/coll-of string? :kind set?))
 
+(s/def :logjam.filter/loggers-allowlist :logjam.filter/loggers)
+
 (s/def :logjam.filter/pattern string?)
 (s/def :logjam.filter/start-time pos-int?)
 
@@ -40,6 +42,7 @@
                    :logjam.filter/exceptions
                    :logjam.filter/level
                    :logjam.filter/loggers
+                   :logjam.filter/loggers-allowlist
                    :logjam.filter/pattern
                    :logjam.filter/start-time
                    :logjam.filter/threads]))


### PR DESCRIPTION
* Rename `:loggers` to `:loggers-allowlist`
  * If both are passed, they're merged, for compat.
* Event filters: introduce `:loggers-blocklist`
  * Fixes https://github.com/clojure-emacs/logjam/issues/13

Cheers - V