### PR TITLE
Handle `java.net.SocketException`s that can be thrown for disconnected clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## master (unreleased)
 
+* [#16](https://github.com/clojure-emacs/logjam/issues/16): handle `java.net.SocketException`s that can be thrown for disconnected clients.
 * Introduce `logjam.appender.default-event-size` configuration option.
-
-* Event filters: rename `:loggers` to `:loggers-allowlist`
 * [#13](https://github.com/clojure-emacs/logjam/issues/13): Event filters: introduce `:loggers-blocklist`.
-* Event filters: rename `:loggers` to `:loggers-allowlist`.
- * `:loggers` will remain supported.
+  * `:loggers` will remain supported.
 
 ## 0.2.0 (2024-01-04)
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                                        [com.taoensso/timbre "6.3.1" :exclusions [org.clojure/clojure]]
                                        [org.clojure/clojure "1.11.1"]]}
 
-             :dev {:plugins [[cider/cider-nrepl "0.44.0"]
+             :dev {:plugins [[cider/cider-nrepl "0.45.0"]
                              [refactor-nrepl "3.9.0"]]}
 
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/logjam/issues/16 (repro can be found there)

The chosen approach was to turn `:consumers` into an atom, so that one can easily remove 'stale' consumers that represent disconnected nREPL clients.

Cheers - V